### PR TITLE
Add error handling for missing account info

### DIFF
--- a/js/app/account.js
+++ b/js/app/account.js
@@ -42,6 +42,7 @@ export async function loadAccount() {
     }
     
     const accountInfoData = await accountInfoLocalStorage.getSettings();
+    if (!accountInfoData) throw new AppError('No account info.  Please visit a page on the Steam Market to populate.');
     const { language } = accountInfoData;
             
     if (!language) {


### PR DESCRIPTION
If you are logged in to Steam but haven't yet browsed a marketplace page you get this error:

TypeError: Cannot destructure property 'language' of 'accountInfoData' as it is undefined.

I propose catching that state and throwing a more helpful error.